### PR TITLE
Frap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+.DS_Store
 
 # Installer logs
 pip-log.txt

--- a/analysis_scripts/Simple_FRAP.py
+++ b/analysis_scripts/Simple_FRAP.py
@@ -54,10 +54,10 @@ def getEllipses(conn, imageId):
     for roi in result.rois:
         for shape in roi.copyShapes():
             if type(shape) == omero.model.EllipseI:
-                cx = int(shape.getCx().getValue())
-                cy = int(shape.getCy().getValue())
-                rx = int(shape.getRx().getValue())
-                ry = int(shape.getRy().getValue())
+                cx = int(shape.getX().getValue())
+                cy = int(shape.getY().getValue())
+                rx = int(shape.getRadiusX().getValue())
+                ry = int(shape.getRadiusY().getValue())
                 z = int(shape.getTheZ().getValue())
                 t = int(shape.getTheT().getValue())
                 ellipses[t] = {'cx': cx, 'cy': cy, 'rx': rx, 'ry': ry, 'z': z}


### PR DESCRIPTION
This PR fixes the way ellipses are handled

To test:

 * Select an image with multiple timepoints (a dv for example not a fake one)
 * Draw an ellipse on a plate and propagate it across t
 * Run the script

Note that the original script is not too robust so you might have "out of bounds" error 
we may want to review that later on.