### PR TITLE
Images_from_ROIS_ZT_None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
   - "2.7"
 virtualenv:
   system_site_packages: true
-install: pip install flake8 --use-mirrors
+install: pip install flake8
 script: flake8 -v .


### PR DESCRIPTION
Fixes ``` File "./script", line 79, in getRectangles t = shape.getTheT().getValue() AttributeError: 'NoneType' object has no attribute 'getValue' ```
reported https://trello.com/c/CwslNIyH/112-review-script-sharing-page#comment-59ba5b78b9b0b3915ac02dc6

To test:
 - Upload the New_Images_From_ROIs.py script edited in this PR.
 - Add some rectangle ROIs to a multi-Z/T image, setting theZ and theT in some cases, in others leaving this null.
 - Run the ```New Images From ROIs.py``` script with this image.
 - Should see that shapes without Z/T handled without error. New images will be created in the Dataset. If shape has No Z/T then new cropped image will include whole Z/T range of the original.